### PR TITLE
Fixing ImportError: cannot import name 'WRITES_IDX_MAP'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 langgraph==0.2.0
 langchain-community==0.2.11
-langgraph-checkpoint==1.0.1
+langgraph-checkpoint==1.0.4
 langchain-openai
 langchain-anthropic
 langgraph-checkpoint-sqlite


### PR DESCRIPTION
This import comes in version 1.0.4 as per Nuno Campos https://github.com/langchain-ai/langgraph/issues/1570